### PR TITLE
Specify tree sitter dependency version to continue use of deprecated method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tree_sitter==0.19.0
+tree_sitter==0.21.1
 requests==2.25.1
 GitPython==3.1.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tree_sitter==0.21.1
+tree_sitter==0.21.3
 requests==2.25.1
 GitPython==3.1.18

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setup(
   download_url = 'https://github.com/cedricrupb/code_ast/archive/refs/tags/v0.1.0.tar.gz',  
   keywords = ['code', 'ast', 'syntax', 'program', 'language processing'], 
   install_requires=[          
-        'tree_sitter==0.21.1',
-        'requests==2.25.1',
+        'tree_sitter==0.21.3',
         'GitPython==3.1.18',
+        'requests==2.25.1',
       ],
   classifiers=[
     'Development Status :: 3 - Alpha',    

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   download_url = 'https://github.com/cedricrupb/code_ast/archive/refs/tags/v0.1.0.tar.gz',  
   keywords = ['code', 'ast', 'syntax', 'program', 'language processing'], 
   install_requires=[          
-        'tree_sitter==0.19.0',
+        'tree_sitter==0.21.1',
         'requests==2.25.1',
         'GitPython==3.1.18',
       ],

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setup(
   download_url = 'https://github.com/cedricrupb/code_ast/archive/refs/tags/v0.1.0.tar.gz',  
   keywords = ['code', 'ast', 'syntax', 'program', 'language processing'], 
   install_requires=[          
-          'tree_sitter',
-          'GitPython',
-          'requests'
+        'tree_sitter==0.19.0',
+        'requests==2.25.1',
+        'GitPython==3.1.18',
       ],
   classifiers=[
     'Development Status :: 3 - Alpha',    


### PR DESCRIPTION
`Language.build_library()` was removed in [py-tree-sitter v22](https://github.com/tree-sitter/py-tree-sitter/releases/tag/v0.22.0). Due to no versions being specified in `setup.py`, the latest version of each dependency is installed by default. I've changed `setup.py` to match the versions specified in `requirements.txt`. Also, I bumped the tree sitter dependency to the most recent usable version.

See [this discussion](https://github.com/tree-sitter/py-tree-sitter/discussions/241) for information related to the method deprecation.


Here's some context for where the method is used in the source:

https://github.com/cedricrupb/code_ast/blob/982940d04b1d721e5ac9a97d433f36d1fb47e8e0/code_ast/parsers.py#L188-L196