### PR TITLE
Can we use `tree-sitter-languages` Instead of auto-downloading parsers and built them from scratch?

### DIFF
--- a/code_ast/parsers.py
+++ b/code_ast/parsers.py
@@ -15,51 +15,12 @@ import logging as logger
 import requests
 from git import Repo
 
-
 # Automatic loading of Tree-Sitter parsers --------------------------------
+from tree_sitter_languages import get_language
 
-def load_language(lang):
-    """
-    Loads a language specification object necessary for tree-sitter.
-
-    Language specifications are loaded from remote or a local cache.
-    If language specification is not contained in cache, the function
-    clones the respective git project and then builds the language specification
-    via tree-sitter.
-    We employ the same language identifier as tree-sitter and
-    lang is translated to a remote repository 
-    (https://github.com/tree-sitter/tree-sitter-[lang]).
-
-    Parameters
-    ----------
-    lang : [python, java, javascript, ...]
-        language identifier specific to tree-sitter.
-        As soon as there is a repository with the same language identifier
-        the language is supported by this function.
-
-    Returns
-    -------
-    Language
-        language specification object
-
-    """
-
-    cache_path = _path_to_local()
-    
-    compiled_lang_path = os.path.join(cache_path, "%s-lang.so" % lang)
-    source_lang_path   = os.path.join(cache_path, "tree-sitter-%s" % lang)
-
-    if os.path.isfile(compiled_lang_path):
-        return Language(compiled_lang_path, _lang_to_fnname(lang))
-    
-    if os.path.exists(source_lang_path) and os.path.isdir(source_lang_path):
-        logger.warn("Compiling language for %s" % lang)
-        _compile_lang(source_lang_path, compiled_lang_path)
-        return load_language(lang)
-
-    logger.warn("Autoloading AST parser for %s: Start download from Github." % lang)
-    _clone_parse_def_from_github(lang, source_lang_path)
-    return load_language(lang)
+def load_language(lang: str)->Language:
+    """Using pre-built binaries from `tree-sitter-languages`"""
+    return get_language(lang)
 
 # Parser ---------------------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tree_sitter==0.19.0
 requests==2.25.1
 GitPython==3.1.18
+tree-sitter-languages==1.10.2


### PR DESCRIPTION
I think this [package](https://github.com/grantjenks/py-tree-sitter-languages) supports a sufficient number of pre-built binaries for language parsers.