### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tree_sitter==0.19.0
+tree-sitter==0.21.3 
 requests==2.25.1
 GitPython==3.1.18


### PR DESCRIPTION
refer to : https://github.com/langchain-ai/langchain/issues/22192

Installing this version tree_sitter causes TypeError: __init__() takes exactly 1 argument (2 given) when invoking code_ast.ast(). Installing version 0.21.3 of tree-sitter fixes the issue.