### PR TITLE
Update requirements.txt

### DIFF
--- a/code_ast/__init__.py
+++ b/code_ast/__init__.py
@@ -19,7 +19,8 @@ from .transformer import (
     ASTTransformer,
     FormattedUpdate,
     TextUpdate,
-    NodeUpdate
+    NodeUpdate,
+    UpdateTree
 )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tree_sitter==0.19.0
+tree_sitter==0.21.3
 requests==2.25.1
 GitPython==3.1.18


### PR DESCRIPTION
Installing this version tree_sitter causes TypeError: init() takes exactly 1 argument (2 given) when invoking code_ast.ast(). Installing version 0.21.3 of tree-sitter fixes the issue